### PR TITLE
Added context menu feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pip install -e .
 |tab_width         |The width of a tab (`\t`)       |Int                                           |
 |autohide_scrollbar|Auto hide scrollbars            |Bool                                          |
 |linenums_border   |Border width of the line numbers|Int                                           |
+|context_menu      |Enable context menus in CodeView|Bool                                          |
 |**kwargs          |Keyword arguments for the widget|Any keyword arguments given to a `Text` widget|
 
 #### Basic Usage:

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ pip install -e .
 # Documentation
 
 ### `CodeView` Widget
-|Options           |Description                     |Input                                         |
-|------------------|--------------------------------|----------------------------------------------|
-|master            |The parent widget               |Tkinter widget                                |
-|lexer             |The Language lexer              |Pygments lexer                                |
-|color_scheme      |A color scheme for the code     |Dict, string, or toml file                    |
-|tab_width         |The width of a tab (`\t`)       |Int                                           |
-|autohide_scrollbar|Auto hide scrollbars            |Bool                                          |
-|linenums_border   |Border width of the line numbers|Int                                           |
-|context_menu      |Enable context menus in CodeView|Bool                                          |
-|**kwargs          |Keyword arguments for the widget|Any keyword arguments given to a `Text` widget|
+|Options             |Description                     |Input                                         |
+|--------------------|--------------------------------|----------------------------------------------|
+|master              |The parent widget               |Tkinter widget                                |
+|lexer               |The Language lexer              |Pygments lexer                                |
+|color_scheme        |A color scheme for the code     |Dict, string, or toml file                    |
+|tab_width           |The width of a tab (`\t`)       |Int                                           |
+|autohide_scrollbar  |Auto hide scrollbars            |Bool                                          |
+|linenums_border     |Border width of the line numbers|Int                                           |
+|default_context_menu|Enable context menus in CodeView|Bool                                          |
+|**kwargs            |Keyword arguments for the widget|Any keyword arguments given to a `Text` widget|
 
 #### Basic Usage:
 ```python

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from contextlib import suppress
 from pathlib import Path
-from tkinter import BaseWidget, Event, Misc, TclError, Text, ttk
+from tkinter import BaseWidget, Event, Menu, Misc, TclError, Text, ttk
 from tkinter.font import Font
 from typing import Any, Callable, Type, Union
 
@@ -48,6 +48,7 @@ class CodeView(Text):
         linenums_theme: Callable[[], tuple[str, str]] | tuple[str, str] | None = None,
         autohide_scrollbar: bool = True,
         linenums_border: int = 0,
+        context_menu: bool = False,
         **kwargs,
     ) -> None:
         self._frame = ttk.Frame(master)
@@ -79,7 +80,18 @@ class CodeView(Text):
             xscrollcommand=self.horizontal_scroll,
             tabs=Font(font=kwargs["font"]).measure(" " * tab_width),
         )
-
+        
+        if context_menu:
+            self.context_menu = Menu(self, tearoff=0)
+            self.context_menu.add_command(label="Undo", command=lambda:self.event_generate("<<Undo>>"))
+            self.context_menu.add_command(label="Redo", command=lambda:self.event_generate("<<Redo>>"))
+            self.context_menu.add_separator()
+            self.context_menu.add_command(label="Cut", command=lambda:self.event_generate("<<Cut>>"))
+            self.context_menu.add_command(label="Copy", command=self._copy)
+            self.context_menu.add_command(label="Paste", command=self._paste)
+            self.context_menu.add_command(label="Select all", command=self._select_all)
+            super().bind("<Button-3>", lambda e:self.context_menu.tk_popup(e.x_root, e.y_root))
+    
         contmand = "Command" if self._windowingsystem == "aqua" else "Control"
 
         super().bind(f"<{contmand}-c>", self._copy, add=True)

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -83,7 +83,7 @@ class CodeView(Text):
         
         self._context_menu = None
         self._default_context_menu = default_context_menu
-    
+        if self._default_context_menu: self.context_menu    
         contmand = "Command" if self._windowingsystem == "aqua" else "Control"
 
         super().bind(f"<{contmand}-c>", self._copy, add=True)

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -105,7 +105,7 @@ class CodeView(Text):
         if self._context_menu is None:
             self._context_menu = self._create_context_menu()
 
-            if super().tk.call("tk", "windowingsystem") == "aqua":
+            if self.tk.call("tk", "windowingsystem") == "aqua":
                 super().bind("<Button-2>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
                 super().bind("<Control-1>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
             else:

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -107,10 +107,6 @@ class CodeView(Text):
             super().bind("<Button-3>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
         return self._context_menu
     
-    @context_menu.setter
-    def context_menu(self, value: Menu) -> None:
-        self._context_menu = value
-
     def _create_context_menu(self) -> Menu:
         context_menu = Menu(self, tearoff=0)
         if self._default_context_menu:

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -106,18 +106,18 @@ class CodeView(Text):
     def context_menu(self) -> Menu:
         if self._context_menu is None:
             self._context_menu = self._create_context_menu()
-            popup_callback = lambda e: self._context_menu.tk_popup(e.x_root + 5, e.y_root + 5)
-
-            if self._windowingsystem == "aqua":
-                super().bind("<Button-2>", popup_callback)
-                super().bind("<Control-Button-1>", popup_callback)
-            else:
-                super().bind("<Button-3>", popup_callback)
 
         return self._context_menu
 
     def _create_context_menu(self) -> Menu:
         context_menu = Menu(self, tearoff=0)
+        popup_callback = lambda e: context_menu.tk_popup(e.x_root + 5, e.y_root + 5)
+
+        if self._windowingsystem == "aqua":
+            super().bind("<Button-2>", popup_callback)
+            super().bind("<Control-Button-1>", popup_callback)
+        else:
+            super().bind("<Button-3>", popup_callback)
 
         if self._default_context_menu:
             contmand = "⌘" if self._windowingsystem == "aqua" else "Ctrl"

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -104,7 +104,7 @@ class CodeView(Text):
     def context_menu(self) -> Menu:
         if self._context_menu is None:
             self._context_menu = self._create_context_menu()
-            super().bind("<Button-3>", lambda e: self._context_menu.tk_popup(e.x_root, e.y_root))
+            super().bind("<Button-3>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
         return self._context_menu
     
     @context_menu.setter

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -104,7 +104,7 @@ class CodeView(Text):
     def context_menu(self) -> Menu:
         if self._context_menu is None:
             self._context_menu = self._create_context_menu()
-            super().bind("<Button-3>", lambda e:self._context_menu.tk_popup(e.x_root, e.y_root))
+            super().bind("<Button-3>", lambda e: self._context_menu.tk_popup(e.x_root, e.y_root))
         return self._context_menu
     
     @context_menu.setter
@@ -114,10 +114,10 @@ class CodeView(Text):
     def _create_context_menu(self) -> Menu:
         context_menu = Menu(self, tearoff=0)
         if self._default_context_menu:
-            context_menu.add_command(label="Undo", command=lambda:self.event_generate("<<Undo>>"))
-            context_menu.add_command(label="Redo", command=lambda:self.event_generate("<<Redo>>"))
+            context_menu.add_command(label="Undo", command=lambda: self.event_generate("<<Undo>>"))
+            context_menu.add_command(label="Redo", command=lambda: self.event_generate("<<Redo>>"))
             context_menu.add_separator()
-            context_menu.add_command(label="Cut", command=lambda:self.event_generate("<<Cut>>"))
+            context_menu.add_command(label="Cut", command=lambda: self.event_generate("<<Cut>>"))
             context_menu.add_command(label="Copy", command=self._copy)
             context_menu.add_command(label="Paste", command=self._paste)
             context_menu.add_command(label="Select all", command=self._select_all)

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -104,7 +104,13 @@ class CodeView(Text):
     def context_menu(self) -> Menu:
         if self._context_menu is None:
             self._context_menu = self._create_context_menu()
-            super().bind("<Button-3>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
+
+            if super().tk.call("tk", "windowingsystem") == "aqua":
+                super().bind("<Button-2>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
+                super().bind("<Control-1>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
+            else:
+                super().bind("<Button-3>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
+
         return self._context_menu
     
     def _create_context_menu(self) -> Menu:

--- a/chlorophyll/codeview.py
+++ b/chlorophyll/codeview.py
@@ -80,10 +80,12 @@ class CodeView(Text):
             xscrollcommand=self.horizontal_scroll,
             tabs=Font(font=kwargs["font"]).measure(" " * tab_width),
         )
-        
+
         self._context_menu = None
         self._default_context_menu = default_context_menu
-        if self._default_context_menu: self.context_menu    
+        if default_context_menu:
+            self.context_menu
+
         contmand = "Command" if self._windowingsystem == "aqua" else "Control"
 
         super().bind(f"<{contmand}-c>", self._copy, add=True)
@@ -104,25 +106,30 @@ class CodeView(Text):
     def context_menu(self) -> Menu:
         if self._context_menu is None:
             self._context_menu = self._create_context_menu()
+            popup_callback = lambda e: self._context_menu.tk_popup(e.x_root + 5, e.y_root + 5)
 
-            if self.tk.call("tk", "windowingsystem") == "aqua":
-                super().bind("<Button-2>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
-                super().bind("<Control-1>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
+            if self._windowingsystem == "aqua":
+                super().bind("<Button-2>", popup_callback)
+                super().bind("<Control-Button-1>", popup_callback)
             else:
-                super().bind("<Button-3>", lambda e: self._context_menu.tk_popup(e.x_root + 10, e.y_root + 10))
+                super().bind("<Button-3>", popup_callback)
 
         return self._context_menu
-    
+
     def _create_context_menu(self) -> Menu:
         context_menu = Menu(self, tearoff=0)
+
         if self._default_context_menu:
-            context_menu.add_command(label="Undo", command=lambda: self.event_generate("<<Undo>>"))
-            context_menu.add_command(label="Redo", command=lambda: self.event_generate("<<Redo>>"))
+            contmand = "⌘" if self._windowingsystem == "aqua" else "Ctrl"
+
+            context_menu.add_command(label="Undo", accelerator=f"{contmand}+Z", command=lambda: self.event_generate("<<Undo>>"))
+            context_menu.add_command(label="Redo", accelerator=f"{contmand}+Y", command=lambda: self.event_generate("<<Redo>>"))
             context_menu.add_separator()
-            context_menu.add_command(label="Cut", command=lambda: self.event_generate("<<Cut>>"))
-            context_menu.add_command(label="Copy", command=self._copy)
-            context_menu.add_command(label="Paste", command=self._paste)
-            context_menu.add_command(label="Select all", command=self._select_all)
+            context_menu.add_command(label="Cut", accelerator=f"{contmand}+X", command=lambda: self.event_generate("<<Cut>>"))
+            context_menu.add_command(label="Copy", accelerator=f"{contmand}+C", command=self._copy)
+            context_menu.add_command(label="Paste", accelerator=f"{contmand}+V", command=self._paste)
+            context_menu.add_command(label="Select all", accelerator=f"{contmand}+A", command=self._select_all)
+
         return context_menu
 
     def _select_all(self, *_) -> str:


### PR DESCRIPTION
I thought I should do something, and thought to add simple context menus to the CodeView widget.
(Honestly, what description you want here?)

One screenshot and code snippet is more than enough.
![image](https://github.com/rdbende/chlorophyll/assets/72214351/10581070-f269-4b11-b135-ab027bfa5eff)
```python
import tkinter as tk
import pygments
from chlorophyll import CodeView

root = tk.Tk()
editor = CodeView(root, undo=True,
        font = "Iosevka\ Curly\ Light\ Extended 14",
        lexer=pygments.lexers.PythonLexer, color_scheme="ayu-dark",
        context_menu=True
    )
editor.context_menu.add_separator()
editor.context_menu.add_command(label="A custom command", command=lambda:print("lame"))

editor.pack(expand=True, fill='both')
root.mainloop()
```